### PR TITLE
Handle API fallback with JSON 404

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,14 @@ app.use('/data', (req, res) => {
 });
 
 app.use((req, res) => {
+  if (req.path.startsWith('/api/')) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
+  if (req.method === 'GET' && req.accepts('html')) {
+    return res.sendFile(indexPath);
+  }
+
   res.status(404).send('Not Found');
 });
 


### PR DESCRIPTION
## Summary
- return a JSON 404 payload for `/api/*` requests handled by the fallback middleware
- continue serving `index.html` for frontend navigations while preserving 404s for other cases

## Testing
- curl -i http://localhost:3000/api/unknown


------
https://chatgpt.com/codex/tasks/task_e_68cafa37fb8483208c2b311d1c698c37