### PR TITLE
Improve Express server security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "helmet": "^8.1.0"
       }
     },
     "node_modules/accepts": {
@@ -379,6 +380,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "helmet": "^8.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,13 +1,42 @@
 const express = require('express');
 const path = require('path');
+const helmet = require('helmet');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 const indexPath = path.join(__dirname, 'index.html');
 
-function sendIndex(request, response) {
-  response.sendFile(indexPath);
+app.disable('x-powered-by');
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        baseUri: ["'self'"],
+        connectSrc: ["'self'"],
+        formAction: ["'self'"],
+        frameAncestors: ["'self'"],
+        imgSrc: ["'self'", 'data:'],
+        objectSrc: ["'none'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", 'https://cdn.jsdelivr.net', "'unsafe-inline'"],
+        fontSrc: ["'self'", 'https://cdn.jsdelivr.net'],
+        upgradeInsecureRequests: [],
+      },
+    },
+    crossOriginEmbedderPolicy: false,
+  })
+);
+
+function sendIndex(request, response, next) {
+  response.setHeader('Cache-Control', 'no-store');
+  response.sendFile(indexPath, (error) => {
+    if (error) {
+      next(error);
+    }
+  });
 }
 
 app.get('/', sendIndex);
@@ -17,16 +46,30 @@ app.use('/data', (req, res) => {
   res.status(404).send('Not Found');
 });
 
-app.use((req, res) => {
+app.use((req, res, next) => {
   if (req.path.startsWith('/api/')) {
     return res.status(404).json({ error: 'Not found' });
   }
 
   if (req.method === 'GET' && req.accepts('html')) {
-    return res.sendFile(indexPath);
+    return sendIndex(req, res, next);
   }
 
   res.status(404).send('Not Found');
+});
+
+app.use((error, req, res, next) => {
+  console.error('Unexpected error while processing request:', error);
+
+  if (res.headersSent) {
+    return next(error);
+  }
+
+  if (req.accepts('json')) {
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+
+  res.status(500).send('Internal Server Error');
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add Helmet with a custom content security policy and disable Express signature headers
- reuse the index sender for HTML fallbacks with cache control and centralize error handling responses

## Testing
- npm audit
- node server.js (then Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68cdde8175b483209913269f4f128ade