### PR TITLE
Fix text visibility when animation script unavailable

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,12 +674,17 @@
         }
 
         [data-animate] {
-            opacity: 0;
-            transform: translateY(45px);
+            opacity: 1;
+            transform: none;
             transition: opacity 0.9s ease, transform 0.9s ease;
         }
 
-        [data-animate].is-visible {
+        .js-enabled [data-animate] {
+            opacity: 0;
+            transform: translateY(45px);
+        }
+
+        .js-enabled [data-animate].is-visible {
             opacity: 1;
             transform: translateY(0);
         }

--- a/public/js/site.js
+++ b/public/js/site.js
@@ -1,5 +1,29 @@
 (function () {
   document.addEventListener('DOMContentLoaded', () => {
+    const animatedElements = document.querySelectorAll('[data-animate]');
+
+    if (animatedElements.length > 0) {
+      if ('IntersectionObserver' in window) {
+        document.body.classList.add('js-enabled');
+        const observer = new IntersectionObserver((entries, obs) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('is-visible');
+              obs.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.25 });
+
+        animatedElements.forEach((element) => {
+          observer.observe(element);
+        });
+      } else {
+        animatedElements.forEach((element) => {
+          element.classList.add('is-visible');
+        });
+      }
+    }
+
     const emberField = document.querySelector('#ember-field');
     if (emberField) {
       const emberCount = window.innerWidth < 768 ? 35 : 70;
@@ -25,19 +49,6 @@
         const translateY = y * intensity * -24;
         item.style.transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
       });
-    });
-
-    const observer = new IntersectionObserver((entries, obs) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('is-visible');
-          obs.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.25 });
-
-    document.querySelectorAll('[data-animate]').forEach((element) => {
-      observer.observe(element);
     });
 
     const progressBar = document.querySelector('.scroll-progress-bar');


### PR DESCRIPTION
## Summary
- default the animated sections to be visible and only hide them when JavaScript enables the animation state
- add a graceful fallback for IntersectionObserver so text remains visible even if the API is missing

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68d35328b8048320929440725413700d